### PR TITLE
Tweaked documentation and made some modifications to verify all itsybitsy m0 modes work

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ There a few options for the UART pins on the itsybitsy m0 for UART flashing.
 
 The SERCOM3 board definition uses these pins:
 ```
-SCA -> Host RXI
+SDA -> Host RXI
 SCL -> Host TXO
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ D3 -> Host TXO
 ### Compiling the bootloader
 There are UART specific board definitions for the itsybitsy M0. To compile:
 ```
-make itsybitsy_m0_UART_SERCOM3
-make itsybitsy_m0_UART_SERCOM0
+make BOARD=itsybitsy_m0_UART_SERCOM3
+make BOARD=itsybitsy_m0_UART_SERCOM0
 ```
 
 ### Bossac sample commands
@@ -33,7 +33,7 @@ bossac --debug --port=tty.usbserial --offset=0x2000 --erase --write --verify --r
 Not sure why but the first attempt to read or write to the board will fail while in UART bootloader mode. My current workaround is to first send an info command (which will fail) and then do the write to update SAMD21 firmware.
 
 ### Warnings
-Using this bootloader firmware will disable the drag and drop, flash drive type of updating. Once this UART bootloader has been flashed to the board you will need to use some type of debugger (JTAG, Atmel ICE, etc) to reflash to bootloader.
+Using this bootloader firmware will disable the drag and drop, flash drive type of updating. Once this UART bootloader has been flashed to the board you will need to a SWD debugger (Atmel ICE or other CMSIS-DAP compatible) to reflash to bootloader with `make burn`. For example, `make BOARD=itsybitsy_m0_UART_SERCOM3 burn`.
 
 ### Prerequisites for running 'make run'
 The make run command looks for a specific version of openocd (0.10.0-arduino1-static) in your 'Arduino15' directory. My Arduino IDE only had version 0.9.0-arduino6-static. To get the 0.10.0 version to install I had to go into the Boards Manager and add the board type 'Arduino nRF52 Boards'. The tools packaged with this board type include openocd 0.10.0.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ bossac --debug --port=tty.usbserial --offset=0x2000 --erase --write --verify --r
 Not sure why but the first attempt to read or write to the board will fail while in UART bootloader mode. My current workaround is to first send an info command (which will fail) and then do the write to update SAMD21 firmware.
 
 ### Warnings
-Using this bootloader firmware will disable the drag and drop, flash drive type of updating. Once this UART bootloader has been flashed to the board you will need to a SWD debugger (Atmel ICE or other CMSIS-DAP compatible) to reflash to bootloader with `make burn`. For example, `make BOARD=itsybitsy_m0_UART_SERCOM3 burn`.
+Using this bootloader firmware MAY disable the drag and drop, flash drive type of updating. Once this UART bootloader has been flashed to the board you will need to a SWD debugger (Atmel ICE or other CMSIS-DAP compatible) to reflash to bootloader with `make burn`. For example, `make BOARD=itsybitsy_m0_UART_SERCOM3 burn`.
 
 ### Prerequisites for running 'make run'
 The make run command looks for a specific version of openocd (0.10.0-arduino1-static) in your 'Arduino15' directory. My Arduino IDE only had version 0.9.0-arduino6-static. To get the 0.10.0 version to install I had to go into the Boards Manager and add the board type 'Arduino nRF52 Boards'. The tools packaged with this board type include openocd 0.10.0.

--- a/boards/itsybitsy_m0_UART_SERCOM0/board_config.h
+++ b/boards/itsybitsy_m0_UART_SERCOM0/board_config.h
@@ -23,8 +23,8 @@
 #define BOOT_USART_PAD_SETTINGS           UART_RX_PAD1_TX_PAD0
 #define BOOT_USART_PAD3                   PINMUX_UNUSED
 #define BOOT_USART_PAD2                   PINMUX_UNUSED
-#define BOOT_USART_PAD1                   PINMUX_PA09C_SERCOM0_PAD1 //Pin D4 on ItsyBitsy M0 -> HOST RXI
-#define BOOT_USART_PAD0                   PINMUX_PA08C_SERCOM0_PAD0 //Pin D3 on ItsyBitsy M0 -> HOST TXO
+#define BOOT_USART_PAD1                   PINMUX_PA09C_SERCOM0_PAD1 //Pin D3 on ItsyBitsy M0 -> HOST TXO
+#define BOOT_USART_PAD0                   PINMUX_PA08C_SERCOM0_PAD0 //Pin D4 on ItsyBitsy M0 -> HOST RXI
 #define BOOT_GCLK_ID_CORE                 SERCOM0_GCLK_ID_CORE
 #define BOOT_GCLK_ID_SLOW                 SERCOM0_GCLK_ID_SLOW
 

--- a/boards/itsybitsy_m0_UART_SERCOM0_ALT1/board_config.h
+++ b/boards/itsybitsy_m0_UART_SERCOM0_ALT1/board_config.h
@@ -20,11 +20,11 @@
 #define BOOT_USART_MODULE                 SERCOM0
 #define BOOT_USART_MASK                   APBAMASK
 #define BOOT_USART_BUS_CLOCK_INDEX        MCLK_APBBMASK_SERCOM0
-#define BOOT_USART_PAD_SETTINGS           UART_RX_PAD1_TX_PAD0
-#define BOOT_USART_PAD3                   PINMUX_UNUSED
-#define BOOT_USART_PAD2                   PINMUX_UNUSED
-#define BOOT_USART_PAD1                   PINMUX_PA10C_SERCOM0_PAD2 //Pin D1 on ItsyBitsy M0 -> HOST RXI
-#define BOOT_USART_PAD0                   PINMUX_PA11C_SERCOM0_PAD3 //Pin D0 on ItsyBitsy M0 -> HOST TXO
+#define BOOT_USART_PAD_SETTINGS           UART_RX_PAD3_TX_PAD2
+#define BOOT_USART_PAD3                   PINMUX_PA11C_SERCOM0_PAD3 //Pin D0/RX on ItsyBitsy M0 -> HOST TXO
+#define BOOT_USART_PAD2                   PINMUX_PA10C_SERCOM0_PAD2 //Pin D1/TX on ItsyBitsy M0 -> HOST RXI
+#define BOOT_USART_PAD1                   PINMUX_UNUSED
+#define BOOT_USART_PAD0                   PINMUX_UNUSED
 #define BOOT_GCLK_ID_CORE                 SERCOM0_GCLK_ID_CORE
 #define BOOT_GCLK_ID_SLOW                 SERCOM0_GCLK_ID_SLOW
 

--- a/boards/itsybitsy_m0_UART_SERCOM3/board_config.h
+++ b/boards/itsybitsy_m0_UART_SERCOM3/board_config.h
@@ -23,8 +23,8 @@
 #define BOOT_USART_PAD_SETTINGS           UART_RX_PAD1_TX_PAD0
 #define BOOT_USART_PAD3                   PINMUX_UNUSED
 #define BOOT_USART_PAD2                   PINMUX_UNUSED
-#define BOOT_USART_PAD1                   PINMUX_PA23C_SERCOM3_PAD1 //Pin 'SCL' on ItsyBitsy M0 -> HOST RXI
-#define BOOT_USART_PAD0                   PINMUX_PA22C_SERCOM3_PAD0 //Pin 'SDA' on ItsyBitsy M0 -> HOST TXO
+#define BOOT_USART_PAD1                   PINMUX_PA23C_SERCOM3_PAD1 //Pin 'SCL' on ItsyBitsy M0 -> HOST TXO
+#define BOOT_USART_PAD0                   PINMUX_PA22C_SERCOM3_PAD0 //Pin 'SDA' on ItsyBitsy M0 -> HOST RXI
 #define BOOT_GCLK_ID_CORE                 SERCOM3_GCLK_ID_CORE
 #define BOOT_GCLK_ID_SLOW                 SERCOM3_GCLK_ID_SLOW
 


### PR DESCRIPTION
The code for SERCOM3, SERCOM0 and SERCOM0_ALT2 all worked, but SERCOM0_ALT1 required some modifications for proper function. The documentation was also reversed or otherwise incorrect in a few spots.

One thing I'm not totally sure about, in README.MD you've got that this fork breaks USB mass storage updating, but that doesn't appear to be the case. I can drag and drop a .uf2 bootloader no problem. Though following your note, I plugged in a CMSIS-DAP debugger which is much faster and easier.

Thanks for all the help - I'm still not quite out of the woods on my own project, but this is EXTREMELY helpful for narrowing down what my issue is.